### PR TITLE
Fix fail to save layer when group change

### DIFF
--- a/terra_layer/serializers.py
+++ b/terra_layer/serializers.py
@@ -70,6 +70,7 @@ class LayerListSerializer(ModelSerializer):
 class LayerDetailSerializer(ModelSerializer):
     fields = FilterFieldSerializer(many=True, read_only=True, source="fields_filters")
     custom_styles = CustomStyleSerializer(many=True, read_only=True)
+    group = PrimaryKeyRelatedField(read_only=True)
 
     @transaction.atomic
     def create(self, validated_data):


### PR DESCRIPTION
When scene is modified while an included layer is modified, the layer change group and than can't be saved anymore as the group id don't exists anymore.